### PR TITLE
fix for adding a position with value 0

### DIFF
--- a/positions/fields.py
+++ b/positions/fields.py
@@ -55,7 +55,7 @@ class PositionField(models.IntegerField):
         current, updated = getattr(model_instance, cache_name)
 
         if add:
-            current, updated = None, updated if updated else current
+            current, updated = None, updated if updated is not None else current
 
         # existing instance, position not modified; no cleanup required
         if current is not None and updated is None:


### PR DESCRIPTION
At the moment, if you add a new item with position 0, the new item is added at the end as if one had entered -1.  This is because the "updated" variable in pre_save is evaluated as a boolean at one point rather than checking if it is None.

Here's the one-line fix. I'd really appreciate a merge -- thanks!
