### PR TITLE
python 3 comaptibility fix: defined basestring

### DIFF
--- a/positions/fields.py
+++ b/positions/fields.py
@@ -9,6 +9,12 @@ try:
 except ImportError:
     now = datetime.datetime.now
 
+# define basestring for python 3
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
+
 
 class PositionField(models.IntegerField):
     def __init__(self, verbose_name=None, name=None, default=-1, collection=None, parent_link=None, unique_for_field=None, unique_for_fields=None, *args, **kwargs):


### PR DESCRIPTION
I'm using PositionField with Django 1.6 and Python 3.3. Since "basestring" is not defined in Python 3.3, I had to define it at the beginning of the fields module to make it work. 
