### PR TITLE
Fix #51 TypeError error when collection field changes (python3 only)

### DIFF
--- a/positions/fields.py
+++ b/positions/fields.py
@@ -90,13 +90,16 @@ class PositionField(models.IntegerField):
             if updated is None:
                 updated = current
             current = None
-        #elif updated is None:
-        #    updated = -1
 
         # existing instance, position not modified; no cleanup required
         if current is not None and updated is None:
             return current
 
+        # if updated is still unknown set the object to the last position,
+        # either it is a new object or collection has been changed
+        if updated is None:
+            updated = -1
+        
         collection_count = self.get_collection(model_instance).count()
         if current is None:
             max_position = collection_count


### PR DESCRIPTION
Comparison with None type in python3 has been prohibited, which caused python to raise error `unorderable types: int() >= NoneType()` on line `if max_position >= updated >= min_position` when updated was None.