### PR TITLE
Retrieve next_sibling per collection on a deleted instance, not just once

### DIFF
--- a/positions/fields.py
+++ b/positions/fields.py
@@ -193,13 +193,13 @@ class PositionField(models.IntegerField):
     def prepare_delete(self, sender, instance, **kwargs):
         next_sibling = self.get_next_sibling(instance)
         if next_sibling:
-            setattr(instance, '_next_sibling_pk', next_sibling.pk)
+            setattr(instance, '_next_sibling_pk' + self.collection[0], next_sibling.pk)
         else:
-            setattr(instance, '_next_sibling_pk', None)
+            setattr(instance, '_next_sibling_pk' + self.collection[0], None)
         pass
 
     def update_on_delete(self, sender, instance, **kwargs):
-        next_sibling_pk = getattr(instance, '_next_sibling_pk', None)
+        next_sibling_pk = getattr(instance, '_next_sibling_pk' + self.collection[0], None)
         if next_sibling_pk:
             try:
                 next_sibling = type(instance)._default_manager.get(pk=next_sibling_pk)
@@ -214,7 +214,7 @@ class PositionField(models.IntegerField):
                     for field in self.auto_now_fields:
                         updates[field.name] = right_now
                 queryset.filter(**{'%s__gt' % self.name: current}).update(**updates)
-        setattr(instance, '_next_sibling_pk', None)
+        setattr(instance, '_next_sibling_pk' + self.collection[0], None)
 
     def update_on_save(self, sender, instance, created, **kwargs):
         collection_changed = self._collection_changed


### PR DESCRIPTION
Delete assumes a given model has only one PositionField and reorders that singular PositionField. In the instance of many position fields, though, each must be reordered respectively.

```python
class ExhibitItem(models.Model):
    exhibit = models.ForeignKey(Exhibit, on_delete=models.CASCADE, blank=True, null=True)
    lesson_plan = models.ForeignKey(LessonPlan, on_delete=models.CASCADE, blank=True, null=True)
    historical_essay = models.ForeignKey(HistoricalEssay, on_delete=models.CASCADE, blank=True, null=True)
    exhibit_order = PositionField(collection='exhibit')
    lesson_plan_order = PositionField(collection='lesson_plan')
    historical_essay_order = PositionField(collection='historical_essay')
```

An `ExhibitItem` may be 3rd in the exhibit, 12th in the lesson plan, and not exist in any historical essays. When that `ExhibitItem` is deleted, the 4th item in the exhibit becomes the 3rd item, AND the 13th item in the lesson plan becomes the 12th. 