### PR TITLE
Update call to get_field_name for Django 1.10+

### DIFF
--- a/positions/managers.py
+++ b/positions/managers.py
@@ -18,7 +18,7 @@ class PositionQuerySet(QuerySet):
         return queryset
 
     def reposition(self, save=True):
-        position_field = self.model._meta.get_field_by_name(self.position_field_name)[0]
+        position_field = self.model._meta.get_field(self.position_field_name)
         post_save.disconnect(position_field.update_on_save, sender=self.model)
         position = 0
         for obj in self.iterator():


### PR DESCRIPTION
reposition() method calls _meta.get_field_by_name() which has been removed from Django 1.10+, replaced by _meta.get_field().

Not sure how far back this would be compatible, but at least to Django 1.8